### PR TITLE
refactor(web): restructure landing page to standardize portfolio schemas

### DIFF
--- a/internal/schema.go
+++ b/internal/schema.go
@@ -108,13 +108,12 @@ type Author struct {
 }
 
 type Landing struct {
-	Header        Header              `yaml:"header"`
-	SystemSpec    SystemSpecification `yaml:"system_specification"`
-	Hero          Hero                `yaml:"hero"`
-	WhatIsReading WhatIsReading       `yaml:"what_is_reading_analytics"`
-	KeyFeatures   KeyFeatures         `yaml:"key_features"`
-	WhyItMatters  WhyItMatters        `yaml:"why_it_matters"`
-	Footer        LandingFooter       `yaml:"footer"`
+	Header Header        `yaml:"header"`
+	LLMS   LLMS          `yaml:"llms"`
+	Tech   Tech          `yaml:"tech"`
+	Proof  Proof         `yaml:"proof"`
+	Reach  Reach         `yaml:"reach"`
+	Footer LandingFooter `yaml:"footer"`
 }
 
 type Header struct {
@@ -122,47 +121,50 @@ type Header struct {
 	SiteURL     string `yaml:"site_url"`
 }
 
-type SystemSpecification struct {
+type LLMS struct {
 	Objective           string `yaml:"objective"`
 	Stack               string `yaml:"stack"`
 	Pattern             string `yaml:"pattern"`
 	EntryPoint          string `yaml:"entry_point"`
 	PersistenceStrategy string `yaml:"persistence_strategy"`
 	Observability       string `yaml:"observability"`
-	MachineRegistry     string `yaml:"machine_registry"`
 }
 
-type Hero struct {
-	Headline         string `yaml:"headline"`
-	SubHeadline      string `yaml:"sub_headline"`
-	BriefDescription string `yaml:"brief_description"`
-	CTAText          string `yaml:"cta_text"`
-	CTALink          string `yaml:"cta_link"`
-	SecondaryCTAText string `yaml:"secondary_cta_text"`
-	SecondaryCTALink string `yaml:"secondary_cta_link"`
-	TertiaryCTAText  string `yaml:"tertiary_cta_text"`
-	TertiaryCTALink  string `yaml:"tertiary_cta_link"`
+type Tech struct {
+	Extractor Component `yaml:"extractor"`
+	Metrics   Component `yaml:"metrics"`
+	Dashboard Component `yaml:"dashboard"`
 }
 
-type WhatIsReading struct {
-	Title   string   `yaml:"title"`
-	Content []string `yaml:"content"`
-}
-
-type KeyFeatures struct {
-	Title    string    `yaml:"title"`
-	Features []Feature `yaml:"features"`
-}
-
-type Feature struct {
-	Name        string `yaml:"name"`
+type Component struct {
 	Description string `yaml:"description"`
-	Icon        string `yaml:"icon"`
 }
 
-type WhyItMatters struct {
-	Title  string   `yaml:"title"`
-	Points []string `yaml:"points"`
+type Proof struct {
+	Reproducibility       Component `yaml:"reproducibility"`
+	AutomatedVerification Component `yaml:"automated_verification"`
+	TelemetryPipeline     Component `yaml:"telemetry_pipeline"`
+}
+
+type Reach struct {
+	ArchitectureBlueprint Blueprint          `yaml:"architecture_blueprint"`
+	HumblePivots          []TradeOff         `yaml:"humble_pivots"`
+	ObjectiveClarity      Component          `yaml:"objective_clarity"`
+	VerifiableOutputs     []VerifiableOutput `yaml:"verifiable_outputs"`
+}
+
+type Blueprint struct {
+	DiagramASCII string `yaml:"diagram_ascii"`
+}
+
+type TradeOff struct {
+	Title       string `yaml:"title"`
+	Description string `yaml:"description"`
+}
+
+type VerifiableOutput struct {
+	Title          string `yaml:"title"`
+	TerminalOutput string `yaml:"terminal_output"`
 }
 
 type LandingFooter struct {

--- a/internal/web/content/landing.yml
+++ b/internal/web/content/landing.yml
@@ -2,58 +2,115 @@ header:
   project_name: "Personal Reading Analytics"
   site_url: "https://victoriacheng15.github.io/personal-reading-analytics"
 
-system_specification:
-  objective: "A zero-infrastructure reading analytics pipeline that transforms personal reading habits into actionable insights using Go, Python, and GitHub Actions."
+llms:
+  objective: "A zero-infrastructure reading analytics pipeline that tracks personal engineering blog consumption and generates insights via Go, Python, and Google Gemini."
   stack: "Go, Python, GitHub Actions, MongoDB Atlas, Google Sheets, Google Gemini"
   pattern: "Event Sourcing / Serverless Pipeline"
   entry_point: "cmd/web/main.go"
   persistence_strategy: "MongoDB (Event Log) + Google Sheets (Current State)"
   observability: "GitHub Actions Logs + MongoDB Event Sourcing"
-  machine_registry: "/api/evolution-registry.json"
 
-hero:
-  headline: "Your Reading, Visualized"
-  sub_headline: "No servers, no noise, just your data."
-  brief_description: "A lightweight analytics system designed to track engineering blog consumption and surface learning patterns without infrastructure overhead."
-  cta_text: "View Analytics"
-  cta_link: "analytics.html"
-  secondary_cta_text: "See the Evolution"
-  secondary_cta_link: "evolution.html"
-  tertiary_cta_text: "View on GitHub"
-  tertiary_cta_link: "https://github.com/victoriacheng15/personal-reading-analytics"
+# Core Components & Logic
+tech:
+  extractor:
+    description: "Universal, configuration-driven Python extractor that automates RSS/web metadata collection, logging event traces to MongoDB and syncing current state to Google Sheets."
+  metrics:
+    description: "Go metrics calculator that aggregates reading volumes, read rates, category distributions, and backlog age profiles into a structured JSON database."
+  dashboard:
+    description: "Go static site generator that compiles HTML templates and compiled Tailwind CSS to produce responsive analytics and historical progression dashboards."
 
-what_is_reading_analytics:
-  title: "Origin Story"
-  content:
-    - "I used to follow a handful of engineering blogs, but checking each one for new posts became a chore, too many tabs, too easy to miss something. (Yes, I’ve definitely had 20+ tabs open at once… 😅)"
-    - "So I built a simple script to automatically pull article titles, dates, and links into Google Sheets, inspired by early Levels.fyi’s “no database” approach. Everything in one place. No more tab-hopping."
-    - "Later, I got curious: What if I could actually see my reading habits over time? Not to “optimize” productivity, but to understand where my attention really goes… and which blogs still earn it."
-    - "That curiosity led me to build a lightweight analytics system in Go, powered by the same Python-collected data. The result? A personal reading analytics: a quiet mirror on my learning journey."
+# Validation & Resiliency Testing
+proof:
+  reproducibility:
+    description: "Standardized Go environments and local Python virtual environments bootstrapped predictably via Makefile automation."
+  automated_verification:
+    description: "Dual-layer testing architecture verifying data parsing logic via Go unit tests and RSS/web extraction routines via Python pytest suites."
+  telemetry_pipeline:
+    description: "Event-sourced pipeline that pushes extraction telemetry, database updates, and failure logs directly to MongoDB Atlas for decoupled auditing."
 
-key_features:
-  title: "Engineering Principles"
-  features:
-    - name: "Zero Infrastructure"
-      description: "No servers or hosting costs. Runs entirely on GitHub Actions and Pages."
-      icon: "🚀"
-    - name: "Fully Automated"
-      description: "Scheduled workflows keep data fresh, utilizing CI/CD governance for human-in-the-loop oversight."
-      icon: "🤖"
-    - name: "Observability First"
-      description: "Uses an Event Sourcing pattern to decouple extraction from analytics, ensuring full auditability."
-      icon: "🛡️"
-    - name: "Cost Effective"
-      description: "Leverages free tiers (GitHub, MongoDB Atlas, Google Sheets) for powerful, budget-free automation."
-      icon: "💰"
+# Design Trade-offs & Verification Logs
+reach:
+  # Architecture Blueprint
+  architecture_blueprint:
+    diagram_ascii: |4
+             ┌───────────────┐
+             │  Google Sheet │
+             └───────────────┘
+                     ▲
+                     │ (Read/Write Articles & Sources)
+                     ▼
+             ┌───────────────┐     (Fetch Metadata)     ┌──────────────────────┐
+             │  Python Extr  │ ───────────────────────> │ RSS/Web Blogs        │
+             │  (Extraction) │                          └──────────────────────┘
+             └───────────────┘
+                     │
+                     │ (Log events)
+                     ▼
+             ┌───────────────┐
+             │  MongoDB      │
+             └───────────────┘
+                     ▲
+                     │ (Query stats)
+                     ▼
+             ┌───────────────┐
+             │  Go Metrics   │
+             └───────────────┘
+                     │
+                     │ (Generate JSON)
+                     ▼
+             ┌───────────────┐
+             │ Go Dashboard  │ ───────────────────────> [ Static HTML/CSS ]
+             │ (Generator)   │                          (GitHub Pages)
+             └───────────────┘
+  humble_pivots:
+    - title: "Caching Google Sheets to Avoid API Rate Limits"
+      description: "Originally, Go metrics queried Google Sheets directly during page builds. This routinely hit API rate limits. Pivoted to using Google Sheets as the SSOT database but logging sync events to MongoDB, letting Go query cached data for stability and speed."
+    - title: "Integrating Generative AI for Qualitative Trend Analysis (ADR 002)"
+      description: "Initially, the system only surfaced quantitative metrics (totals, read rates). Pivoted to integrating Google Gemini (GenAI) to analyze the differences (deltas) between pipeline runs, generating qualitative learning insights."
+    - title: "Decoupling Dashboard Generation from Live Database Queries"
+      description: "Originally, the Go static site generator queried MongoDB Atlas directly during compilation to retrieve historical trends. Pivoted to reading pre-computed local daily JSON metrics files, allowing the dashboard generator to build instantly and offline without database network dependencies."
+  objective_clarity:
+    description: "Serves strictly as a personal, static, read-only dashboard. Does not support multi-user authenticated views, write operations outside of the extraction scheduler, or high-concurrency database queries."
+  verifiable_outputs:
+    - title: "Go Test Suite (make test-go)"
+      terminal_output: |
+        go test -v ./cmd/... ./internal/...
+        === RUN   TestCalculateTopReadRateSource
+        --- PASS: TestCalculateTopReadRateSource (0.00s)
+        === RUN   TestCalculateMostUnreadSource
+        --- PASS: TestCalculateMostUnreadSource (0.00s)
+        === RUN   TestCalculateThisMonthArticles
+        --- PASS: TestCalculateThisMonthArticles (0.00s)
+        PASS
+        ok  	github.com/victoriacheng15/personal-reading-analytics/internal/metrics	0.003s
+        === RUN   TestGetTemplatesDir
+        === RUN   TestGetTemplatesDir/finds_templates_directory_from_primary_path
+        === RUN   TestGetTemplatesDir/finds_templates_directory_from_relative_path
+        === RUN   TestGetTemplatesDir/returns_error_when_templates_directory_not_found
+        --- PASS: TestGetTemplatesDir (0.00s)
+            --- PASS: TestGetTemplatesDir/finds_templates_directory_from_primary_path (0.00s)
+            --- PASS: TestGetTemplatesDir/finds_templates_directory_from_relative_path (0.00s)
+            --- PASS: TestGetTemplatesDir/returns_error_when_templates_directory_not_found (0.00s)
+        === RUN   TestLoadEvolutionData
+        === RUN   TestLoadEvolutionData/loads_evolution_data_successfully
+        === RUN   TestLoadEvolutionData/returns_error_when_file_missing
+        --- PASS: TestLoadEvolutionData (0.00s)
+            --- PASS: TestLoadEvolutionData/loads_evolution_data_successfully (0.00s)
+            --- PASS: TestLoadEvolutionData/returns_error_when_file_missing (0.00s)
+        PASS
+        ok  	github.com/victoriacheng15/personal-reading-analytics/internal/web	0.010s
+    - title: "Python Test Suite (make test-py)"
+      terminal_output: |
+        .venv/bin/pytest script/
+        ============================= test session starts ==============================
+        platform linux -- Python 3.12.3, pytest-8.3.4, pluggy-1.5.1
+        configfile: pyproject.toml
+        plugins: cov-6.0.0
+        collected 3 items
 
-why_it_matters:
-  title: "Mastering the Information Stream"
-  points:
-    - "Data Ownership: Complete control over your reading history and metrics."
-    - "Operational Simplicity: Proves that sophisticated automation doesn't require a large budget."
-    - "Actionable Insights: Identifies high-value sources and reading trends over time."
-    - "Educational Laboratory: A playground for testing Go, Python, and Event Sourcing patterns."
-    - "Minimalist Design: Focuses on domain value by eliminating infrastructure 'plumbing'."
+        script/test_extractor.py ...                                             [100%]
+
+        ============================== 3 passed in 0.32s ================================================
 
 footer:
   author: "Victoria Cheng"

--- a/internal/web/service.go
+++ b/internal/web/service.go
@@ -488,7 +488,7 @@ func (s *AnalyticsService) generateRegistry(vm ViewModel, outputDir string) erro
 		Project:            vm.Landing.Header.ProjectName,
 		Version:            "1.0.0",
 		LastUpdated:        vm.LastUpdated.Format("2006-01-02"),
-		MachineRegistryURL: vm.Landing.SystemSpec.MachineRegistry,
+		MachineRegistryURL: "/api/evolution-registry.json",
 	}
 
 	for _, chapter := range vm.EvolutionData.Chapters {

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -3,64 +3,119 @@
     <!-- Hero Section -->
     <section aria-label="Hero" class="flex flex-col gap-8 text-center items-center py-12">
         <h1 class="text-5xl font-extrabold text-slate-900 tracking-tight leading-tight">
-            {{.Landing.Hero.Headline}}
+            {{.Landing.Header.ProjectName}}
         </h1>
-        <p class="text-2xl text-sky-800 font-medium">{{.Landing.Hero.SubHeadline}}</p>
-        <p class="text-xl text-slate-600 max-w-2xl leading-relaxed">
-            {{.Landing.Hero.BriefDescription}}
+        <p class="text-2xl text-sky-800 font-medium max-w-2xl leading-relaxed">
+            {{.Landing.LLMS.Objective}}
         </p>
         <div class="flex flex-wrap gap-4 justify-center mt-4">
-            <a href="{{.Landing.Hero.CTALink}}" class="px-8 py-3 rounded-xl font-bold text-lg transition-all hover:-translate-y-1 hover:shadow-lg shadow-md bg-sky-700 text-white hover:bg-sky-800">
-                {{.Landing.Hero.CTAText}}
+            <a href="analytics.html" class="px-8 py-3 rounded-xl font-bold text-lg transition-all hover:-translate-y-1 hover:shadow-lg shadow-md bg-sky-700 text-white hover:bg-sky-800">
+                View Analytics
             </a>
-            <a href="{{.Landing.Hero.SecondaryCTALink}}" class="px-8 py-3 rounded-xl font-bold text-lg transition-all hover:-translate-y-1 hover:shadow-lg shadow-md bg-white text-sky-700 border-2 border-sky-700 hover:bg-sky-50">
-                {{.Landing.Hero.SecondaryCTAText}}
+            <a href="evolution.html" class="px-8 py-3 rounded-xl font-bold text-lg transition-all hover:-translate-y-1 hover:shadow-lg shadow-md bg-slate-50 text-sky-700 border-2 border-sky-700 hover:bg-slate-100">
+                See the Evolution
             </a>
-            <a href="{{.Landing.Hero.TertiaryCTALink}}" target="_blank" rel="noopener noreferrer" class="px-8 py-3 rounded-xl font-bold text-lg transition-all hover:-translate-y-1 hover:shadow-lg shadow-md bg-slate-50 text-slate-700 border-2 border-slate-200 hover:border-sky-700">
-                {{.Landing.Hero.TertiaryCTAText}}
+            <a href="{{.Landing.Footer.GitHubLink}}/personal-reading-analytics" target="_blank" rel="noopener noreferrer" class="px-8 py-3 rounded-xl font-bold text-lg transition-all hover:-translate-y-1 hover:shadow-lg shadow-md bg-slate-50 text-slate-700 border-2 border-slate-200 hover:border-sky-700">
+                View on GitHub
             </a>
         </div>
     </section>
 
-    <!-- What Is It -->
-    <section aria-label="{{.Landing.WhatIsReading.Title}}" class="flex flex-col gap-6">
-        <h2 class="text-2xl font-bold text-slate-800 border-b-4 border-sky-700 pb-2 self-start">{{.Landing.WhatIsReading.Title}}</h2>
-        <div class="bg-white border-2 border-slate-200 rounded-2xl p-8 shadow-sm flex flex-col gap-6 text-slate-700 leading-relaxed text-lg italic border-l-8 border-l-sky-700">
-            {{range .Landing.WhatIsReading.Content}}
-            <p>{{.}}</p>
-            {{end}}
+    <!-- Architecture Blueprint -->
+    <section aria-label="Architecture Blueprint" class="flex flex-col gap-8">
+        <h2 class="text-2xl font-bold text-slate-800 border-b-4 border-sky-700 pb-2 self-start">Architecture Blueprint</h2>
+        <div class="flex flex-col gap-4 bg-slate-100/70 border-2 border-slate-200 rounded-2xl p-6 shadow-sm">
+            <pre class="bg-slate-900 text-cyan-400 p-6 rounded-xl font-mono text-xs overflow-x-auto leading-normal whitespace-pre"><code>{{.Landing.Reach.ArchitectureBlueprint.DiagramASCII}}</code></pre>
         </div>
     </section>
 
-    <!-- Key Features -->
-    <section aria-label="Core Principles" class="flex flex-col gap-8">
-        <h2 class="text-2xl font-bold text-slate-800 border-b-4 border-sky-700 pb-2 self-start">{{.Landing.KeyFeatures.Title}}</h2>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-            {{range .Landing.KeyFeatures.Features}}
-            <article class="bg-white border-2 border-slate-200 rounded-2xl p-8 flex flex-col gap-4 transition-all hover:shadow-md group border-b-8 border-b-slate-100 hover:border-b-sky-700">
-                <div class="text-4xl group-hover:scale-110 transition-transform self-start">
-                    <span role="img" aria-hidden="true" class="bg-sky-100 p-3 rounded-xl block">{{.Icon}}</span>
-                </div>
-                <h3 class="text-xl font-bold text-sky-800 tracking-wide uppercase">{{.Name}}</h3>
-                <p class="text-slate-600 leading-relaxed">{{.Description}}</p>
+    <!-- Core Components -->
+    <section aria-label="Core Components" class="flex flex-col gap-8">
+        <h2 class="text-2xl font-bold text-slate-800 border-b-4 border-sky-700 pb-2 self-start">Core Components</h2>
+        <div class="flex flex-col gap-6">
+            <article class="bg-slate-100/70 border-2 border-slate-200 rounded-2xl p-8 flex flex-col gap-4 shadow-sm transition-all hover:-translate-y-1 hover:shadow-lg hover:border-sky-700">
+                <h3 class="text-xl font-bold text-sky-800 tracking-wide uppercase">Extractor</h3>
+                <p class="text-slate-600 leading-relaxed text-sm">{{.Landing.Tech.Extractor.Description}}</p>
             </article>
-            {{end}}
+            <article class="bg-slate-100/70 border-2 border-slate-200 rounded-2xl p-8 flex flex-col gap-4 shadow-sm transition-all hover:-translate-y-1 hover:shadow-lg hover:border-sky-700">
+                <h3 class="text-xl font-bold text-sky-800 tracking-wide uppercase">Metrics</h3>
+                <p class="text-slate-600 leading-relaxed text-sm">{{.Landing.Tech.Metrics.Description}}</p>
+            </article>
+            <article class="bg-slate-100/70 border-2 border-slate-200 rounded-2xl p-8 flex flex-col gap-4 shadow-sm transition-all hover:-translate-y-1 hover:shadow-lg hover:border-sky-700">
+                <h3 class="text-xl font-bold text-sky-800 tracking-wide uppercase">Dashboard</h3>
+                <p class="text-slate-600 leading-relaxed text-sm">{{.Landing.Tech.Dashboard.Description}}</p>
+            </article>
         </div>
     </section>
 
-    <!-- Why It Matters -->
-    <section aria-label="Why It Matters" class="flex flex-col gap-8">
-        <h2 class="text-2xl font-bold text-slate-800 border-b-4 border-sky-700 pb-2 self-start">{{.Landing.WhyItMatters.Title}}</h2>
-        <div class="flex flex-col gap-4">
-            {{range .Landing.WhyItMatters.Points}}
-            <div class="flex items-center gap-4 bg-slate-50 p-6 rounded-2xl border-2 border-slate-200 transition-all hover:border-sky-700 hover:shadow-md">
-                <span class="text-sky-600 font-bold text-xl">✓</span>
-                <span class="text-slate-700 font-bold text-lg leading-relaxed">{{.}}</span>
+    <!-- Validation & Resiliency -->
+    <section aria-label="Validation and Resiliency" class="flex flex-col gap-8">
+        <h2 class="text-2xl font-bold text-slate-800 border-b-4 border-sky-700 pb-2 self-start">Validation & Resiliency</h2>
+        <div class="flex flex-col gap-6">
+            <div class="bg-slate-100/70 border-2 border-slate-200 rounded-2xl p-8 flex flex-col gap-4 shadow-sm transition-all hover:-translate-y-1 hover:shadow-lg hover:border-sky-700">
+                <div class="flex items-center gap-3">
+                    <span role="img" aria-label="Reproducibility" class="text-2xl">🛠️</span>
+                    <h3 class="font-bold text-slate-800 text-lg uppercase tracking-wide">Reproducibility</h3>
+                </div>
+                <p class="text-slate-600 text-sm leading-relaxed">{{.Landing.Proof.Reproducibility.Description}}</p>
             </div>
-            {{end}}
+            <div class="bg-slate-100/70 border-2 border-slate-200 rounded-2xl p-8 flex flex-col gap-4 shadow-sm transition-all hover:-translate-y-1 hover:shadow-lg hover:border-sky-700">
+                <div class="flex items-center gap-3">
+                    <span role="img" aria-label="Verification" class="text-2xl">✅</span>
+                    <h3 class="font-bold text-slate-800 text-lg uppercase tracking-wide">Verification</h3>
+                </div>
+                <p class="text-slate-600 text-sm leading-relaxed">{{.Landing.Proof.AutomatedVerification.Description}}</p>
+            </div>
+            <div class="bg-slate-100/70 border-2 border-slate-200 rounded-2xl p-8 flex flex-col gap-4 shadow-sm transition-all hover:-translate-y-1 hover:shadow-lg hover:border-sky-700">
+                <div class="flex items-center gap-3">
+                    <span role="img" aria-label="Telemetry" class="text-2xl">📡</span>
+                    <h3 class="font-bold text-slate-800 text-lg uppercase tracking-wide">Telemetry</h3>
+                </div>
+                <p class="text-slate-600 text-sm leading-relaxed">{{.Landing.Proof.TelemetryPipeline.Description}}</p>
+            </div>
         </div>
     </section>
 
+    <!-- Design Trade-offs & Verification Logs -->
+    <section aria-label="Design Trade-offs" class="flex flex-col gap-8">
+        <h2 class="text-2xl font-bold text-slate-800 border-b-4 border-sky-700 pb-2 self-start">Design Trade-offs</h2>
+        
+        <!-- Pivots -->
+        <div class="bg-slate-100/70 border-2 border-slate-200 border-l-8 border-l-amber-500 rounded-2xl p-8 flex flex-col gap-6 shadow-sm hover:shadow-lg hover:-translate-y-1 hover:border-amber-600 transition-all">
+            <h3 class="text-xl font-bold text-slate-800 uppercase tracking-wide border-b-2 border-slate-200 pb-1">Humble Pivots</h3>
+            <div class="flex flex-col gap-6">
+                {{range $index, $element := .Landing.Reach.HumblePivots}}
+                {{if $index}}<hr class="border-slate-100">{{end}}
+                <div class="flex flex-col gap-2">
+                    <h4 class="font-bold text-sky-800 text-lg">{{.Title}}</h4>
+                    <p class="text-slate-600 text-sm leading-relaxed">{{.Description}}</p>
+                </div>
+                {{end}}
+            </div>
+        </div>
+
+        <!-- Objective Clarity -->
+        <div class="bg-slate-100/70 border-2 border-slate-200 border-l-8 border-l-amber-500 rounded-2xl p-8 flex flex-col gap-6 shadow-sm hover:shadow-lg hover:-translate-y-1 hover:border-amber-600 transition-all">
+            <h3 class="text-xl font-bold text-slate-800 uppercase tracking-wide border-b-2 border-slate-200 pb-1">Objective Clarity</h3>
+            <p class="text-slate-600 text-sm leading-relaxed">{{.Landing.Reach.ObjectiveClarity.Description}}</p>
+        </div>
+
+        <!-- Verifiable Outputs -->
+        <div class="flex flex-col gap-6">
+            <h3 class="text-lg font-bold text-slate-800 uppercase tracking-wide">Verifiable Outputs</h3>
+            <div class="flex flex-col gap-6">
+                {{range .Landing.Reach.VerifiableOutputs}}
+                <div class="flex flex-col gap-3 bg-slate-100/70 border-2 border-slate-200 rounded-2xl p-6 shadow-sm transition-all hover:-translate-y-1 hover:shadow-lg">
+                    <h4 class="font-bold text-slate-800 text-sm uppercase tracking-wider flex items-center gap-2">
+                        <span class="w-2.5 h-2.5 rounded-full bg-emerald-500 animate-pulse"></span>
+                        {{.Title}}
+                    </h4>
+                    <pre class="bg-slate-900 text-slate-200 p-4 rounded-xl font-mono text-xs overflow-x-auto whitespace-pre"><code>{{.TerminalOutput}}</code></pre>
+                </div>
+                {{end}}
+            </div>
+        </div>
+    </section>
 </main>
 {{end}}
 {{template "base" .}}

--- a/internal/web/templates/static/llms.txt
+++ b/internal/web/templates/static/llms.txt
@@ -1,24 +1,16 @@
-# {{ .Landing.Header.ProjectName }} - System Specification
+# {{ .Landing.Header.ProjectName }}
 
 ## Objective
-
-{{ .Landing.SystemSpec.Objective }}
+{{ .Landing.LLMS.Objective }}
 
 ## Technical Stack
-
-{{ .Landing.SystemSpec.Stack }}
+{{ .Landing.LLMS.Stack }}
 
 ## Core Architecture
+- **Pattern:** {{ .Landing.LLMS.Pattern }}
+- **Entry Point:** {{ .Landing.LLMS.EntryPoint }}
+- **Persistence Strategy:** {{ .Landing.LLMS.PersistenceStrategy }}
+- **Observability:** {{ .Landing.LLMS.Observability }}
 
-- **Pattern**: {{ .Landing.SystemSpec.Pattern }}
-- **Entry Point**: {{ .Landing.SystemSpec.EntryPoint }}
-- **Persistence Strategy**: {{ .Landing.SystemSpec.PersistenceStrategy }}
-- **Observability**: {{ .Landing.SystemSpec.Observability }}
-
-## Discovery & Registry
-
-- **Machine Registry**: {{ .Landing.Header.SiteURL }}{{ .Landing.SystemSpec.MachineRegistry }}
-
-## Key
-
-- **GitHub Repository**: {{ .Landing.Hero.CTALink }}
+## Resource Links
+- **Code Repository:** {{ .Landing.Footer.GitHubLink }}/personal-reading-analytics


### PR DESCRIPTION
### Summary
This change restructures the landing page configuration and system specification templates to conform to standardized portfolio showcase schemas. It updates the internal Go schemas, the site generator service, and the index templates to render the system components, verification test logs, and architectural trade-offs in a cohesive single-column layout.

### List of Changes
- Restructures the project landing configuration and the LLMs context specification template to align with standardized showcase schemas.
- Adapts the internal Go data structures and template rendering logic to output system components, automated test verifications, and trade-off pivots in a clean card layout.

### Verification
- [x] `make test-go` and `make test-py` passed.
- [x] `make web-build` compiled successfully.

