### PR TITLE
refactor(web): standardize landing page schema and model layout

### DIFF
--- a/internal/schema.go
+++ b/internal/schema.go
@@ -108,12 +108,13 @@ type Author struct {
 }
 
 type Landing struct {
-	Header Header        `yaml:"header"`
-	LLMS   LLMS          `yaml:"llms"`
-	Tech   Tech          `yaml:"tech"`
-	Proof  Proof         `yaml:"proof"`
-	Reach  Reach         `yaml:"reach"`
-	Footer LandingFooter `yaml:"footer"`
+	Header       Header        `yaml:"header"`
+	LLMS         LLMS          `yaml:"llms"`
+	Architecture Architecture  `yaml:"architecture"`
+	Tech         []Tech        `yaml:"tech"`
+	Proof        []Proof       `yaml:"proof"`
+	Reach        Reach         `yaml:"reach"`
+	Footer       LandingFooter `yaml:"footer"`
 }
 
 type Header struct {
@@ -130,35 +131,32 @@ type LLMS struct {
 	Observability       string `yaml:"observability"`
 }
 
-type Tech struct {
-	Extractor Component `yaml:"extractor"`
-	Metrics   Component `yaml:"metrics"`
-	Dashboard Component `yaml:"dashboard"`
+type Architecture struct {
+	DiagramASCII string `yaml:"diagram_ascii"`
 }
 
-type Component struct {
+type Tech struct {
+	Title       string `yaml:"title"`
 	Description string `yaml:"description"`
 }
 
 type Proof struct {
-	Reproducibility       Component `yaml:"reproducibility"`
-	AutomatedVerification Component `yaml:"automated_verification"`
-	TelemetryPipeline     Component `yaml:"telemetry_pipeline"`
+	Title       string `yaml:"title"`
+	Description string `yaml:"description"`
 }
 
 type Reach struct {
-	ArchitectureBlueprint Blueprint          `yaml:"architecture_blueprint"`
-	HumblePivots          []TradeOff         `yaml:"humble_pivots"`
-	ObjectiveClarity      Component          `yaml:"objective_clarity"`
-	VerifiableOutputs     []VerifiableOutput `yaml:"verifiable_outputs"`
+	HumblePivots      []Pivot            `yaml:"humble_pivots"`
+	ObjectiveClarity  ObjectiveClarity   `yaml:"objective_clarity"`
+	VerifiableOutputs []VerifiableOutput `yaml:"verifiable_outputs"`
 }
 
-type Blueprint struct {
-	DiagramASCII string `yaml:"diagram_ascii"`
-}
-
-type TradeOff struct {
+type Pivot struct {
 	Title       string `yaml:"title"`
+	Description string `yaml:"description"`
+}
+
+type ObjectiveClarity struct {
 	Description string `yaml:"description"`
 }
 

--- a/internal/web/content/landing.yml
+++ b/internal/web/content/landing.yml
@@ -10,29 +10,9 @@ llms:
   persistence_strategy: "MongoDB (Event Log) + Google Sheets (Current State)"
   observability: "GitHub Actions Logs + MongoDB Event Sourcing"
 
-# Core Components & Logic
-tech:
-  extractor:
-    description: "Universal, configuration-driven Python extractor that automates RSS/web metadata collection, logging event traces to MongoDB and syncing current state to Google Sheets."
-  metrics:
-    description: "Go metrics calculator that aggregates reading volumes, read rates, category distributions, and backlog age profiles into a structured JSON database."
-  dashboard:
-    description: "Go static site generator that compiles HTML templates and compiled Tailwind CSS to produce responsive analytics and historical progression dashboards."
-
-# Validation & Resiliency Testing
-proof:
-  reproducibility:
-    description: "Standardized Go environments and local Python virtual environments bootstrapped predictably via Makefile automation."
-  automated_verification:
-    description: "Dual-layer testing architecture verifying data parsing logic via Go unit tests and RSS/web extraction routines via Python pytest suites."
-  telemetry_pipeline:
-    description: "Event-sourced pipeline that pushes extraction telemetry, database updates, and failure logs directly to MongoDB Atlas for decoupled auditing."
-
-# Design Trade-offs & Verification Logs
-reach:
-  # Architecture Blueprint
-  architecture_blueprint:
-    diagram_ascii: |4
+# Architecture Blueprint
+architecture:
+  diagram_ascii: |4
              ┌───────────────┐
              │  Google Sheet │
              └───────────────┘
@@ -62,6 +42,27 @@ reach:
              │ Go Dashboard  │ ───────────────────────> [ Static HTML/CSS ]
              │ (Generator)   │                          (GitHub Pages)
              └───────────────┘
+
+# Core Components & Logic
+tech:
+  - title: "extractor"
+    description: "Universal, configuration-driven Python extractor that automates RSS/web metadata collection, logging event traces to MongoDB and syncing current state to Google Sheets."
+  - title: "metrics"
+    description: "Go metrics calculator that aggregates reading volumes, read rates, category distributions, and backlog age profiles into a structured JSON database."
+  - title: "dashboard"
+    description: "Go static site generator that compiles HTML templates and compiled Tailwind CSS to produce responsive analytics and historical progression dashboards."
+
+# Validation & Resiliency Testing
+proof:
+  - title: "Reproducibility"
+    description: "Standardized Go environments and local Python virtual environments bootstrapped predictably via Makefile automation."
+  - title: "Automated Verification"
+    description: "Dual-layer testing architecture verifying data parsing logic via Go unit tests and RSS/web extraction routines via Python pytest suites."
+  - title: "Telemetry Pipeline"
+    description: "Event-sourced pipeline that pushes extraction telemetry, database updates, and failure logs directly to MongoDB Atlas for decoupled auditing."
+
+# Design Trade-offs & Verification Logs
+reach:
   humble_pivots:
     - title: "Caching Google Sheets to Avoid API Rate Limits"
       description: "Originally, Go metrics queried Google Sheets directly during page builds. This routinely hit API rate limits. Pivoted to using Google Sheets as the SSOT database but logging sync events to MongoDB, letting Go query cached data for stability and speed."

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -22,7 +22,7 @@
     <section aria-label="Architecture Blueprint" class="flex flex-col gap-8">
         <h2 class="text-2xl font-bold text-slate-800 border-b-4 border-sky-700 pb-2 self-start">Architecture Blueprint</h2>
         <div class="flex flex-col gap-4 bg-slate-100/70 border-2 border-slate-200 rounded-2xl p-6 shadow-sm">
-            <pre class="bg-slate-900 text-cyan-400 p-6 rounded-xl font-mono text-xs overflow-x-auto leading-normal whitespace-pre"><code>{{.Landing.Reach.ArchitectureBlueprint.DiagramASCII}}</code></pre>
+            <pre class="bg-slate-900 text-cyan-400 p-6 rounded-xl font-mono text-xs overflow-x-auto leading-normal whitespace-pre"><code>{{.Landing.Architecture.DiagramASCII}}</code></pre>
         </div>
     </section>
 
@@ -30,18 +30,12 @@
     <section aria-label="Core Components" class="flex flex-col gap-8">
         <h2 class="text-2xl font-bold text-slate-800 border-b-4 border-sky-700 pb-2 self-start">Core Components</h2>
         <div class="flex flex-col gap-6">
+            {{range .Landing.Tech}}
             <article class="bg-slate-100/70 border-2 border-slate-200 rounded-2xl p-8 flex flex-col gap-4 shadow-sm transition-all hover:-translate-y-1 hover:shadow-lg hover:border-sky-700">
-                <h3 class="text-xl font-bold text-sky-800 tracking-wide uppercase">Extractor</h3>
-                <p class="text-slate-600 leading-relaxed text-sm">{{.Landing.Tech.Extractor.Description}}</p>
+                <h3 class="text-xl font-bold text-sky-800 tracking-wide uppercase">{{.Title}}</h3>
+                <p class="text-slate-600 leading-relaxed text-sm">{{.Description}}</p>
             </article>
-            <article class="bg-slate-100/70 border-2 border-slate-200 rounded-2xl p-8 flex flex-col gap-4 shadow-sm transition-all hover:-translate-y-1 hover:shadow-lg hover:border-sky-700">
-                <h3 class="text-xl font-bold text-sky-800 tracking-wide uppercase">Metrics</h3>
-                <p class="text-slate-600 leading-relaxed text-sm">{{.Landing.Tech.Metrics.Description}}</p>
-            </article>
-            <article class="bg-slate-100/70 border-2 border-slate-200 rounded-2xl p-8 flex flex-col gap-4 shadow-sm transition-all hover:-translate-y-1 hover:shadow-lg hover:border-sky-700">
-                <h3 class="text-xl font-bold text-sky-800 tracking-wide uppercase">Dashboard</h3>
-                <p class="text-slate-600 leading-relaxed text-sm">{{.Landing.Tech.Dashboard.Description}}</p>
-            </article>
+            {{end}}
         </div>
     </section>
 
@@ -49,27 +43,23 @@
     <section aria-label="Validation and Resiliency" class="flex flex-col gap-8">
         <h2 class="text-2xl font-bold text-slate-800 border-b-4 border-sky-700 pb-2 self-start">Validation & Resiliency</h2>
         <div class="flex flex-col gap-6">
+            {{range .Landing.Proof}}
             <div class="bg-slate-100/70 border-2 border-slate-200 rounded-2xl p-8 flex flex-col gap-4 shadow-sm transition-all hover:-translate-y-1 hover:shadow-lg hover:border-sky-700">
                 <div class="flex items-center gap-3">
+                    {{if eq .Title "Reproducibility"}}
                     <span role="img" aria-label="Reproducibility" class="text-2xl">🛠️</span>
-                    <h3 class="font-bold text-slate-800 text-lg uppercase tracking-wide">Reproducibility</h3>
-                </div>
-                <p class="text-slate-600 text-sm leading-relaxed">{{.Landing.Proof.Reproducibility.Description}}</p>
-            </div>
-            <div class="bg-slate-100/70 border-2 border-slate-200 rounded-2xl p-8 flex flex-col gap-4 shadow-sm transition-all hover:-translate-y-1 hover:shadow-lg hover:border-sky-700">
-                <div class="flex items-center gap-3">
+                    {{else if or (eq .Title "Automated Verification") (eq .Title "Verification")}}
                     <span role="img" aria-label="Verification" class="text-2xl">✅</span>
-                    <h3 class="font-bold text-slate-800 text-lg uppercase tracking-wide">Verification</h3>
-                </div>
-                <p class="text-slate-600 text-sm leading-relaxed">{{.Landing.Proof.AutomatedVerification.Description}}</p>
-            </div>
-            <div class="bg-slate-100/70 border-2 border-slate-200 rounded-2xl p-8 flex flex-col gap-4 shadow-sm transition-all hover:-translate-y-1 hover:shadow-lg hover:border-sky-700">
-                <div class="flex items-center gap-3">
+                    {{else if or (eq .Title "Telemetry Pipeline") (eq .Title "Telemetry")}}
                     <span role="img" aria-label="Telemetry" class="text-2xl">📡</span>
-                    <h3 class="font-bold text-slate-800 text-lg uppercase tracking-wide">Telemetry</h3>
+                    {{else}}
+                    <span role="img" aria-label="Info" class="text-2xl">📋</span>
+                    {{end}}
+                    <h3 class="font-bold text-slate-800 text-lg uppercase tracking-wide">{{.Title}}</h3>
                 </div>
-                <p class="text-slate-600 text-sm leading-relaxed">{{.Landing.Proof.TelemetryPipeline.Description}}</p>
+                <p class="text-slate-600 text-sm leading-relaxed">{{.Description}}</p>
             </div>
+            {{end}}
         </div>
     </section>
 


### PR DESCRIPTION
### Summary
Standardizes the portfolio landing schema structure to match the generic multi-project skeleton. This restructures content items under the tech, proof, and reach sections into lists and direct diagram nodes, ensuring layout consistency across repositories. The Go backend models are refactored to parse the new structure seamlessly.

### List of Changes
- Aligns the project's landing configuration and Go parsing structures with the standardized portfolio showcase skeleton.
- Promotes clean layout rendering by decoupling the template views from static fields and dynamically looping over component list nodes.

### Verification
- [x] Run `make test-go`
- [x] Run `make web-build`

